### PR TITLE
Dependency Fix

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -4,6 +4,9 @@
     "author" : "Marcin Sciesinski <marcins78@gmail.com>, Esa-Petri, Metouto, Josharias, Skaldarnar",
     "displayName" : "PlantPack",
     "description" : "Provides basic plant assets",
-    "dependencies" : [],
+    "dependencies" :
+    [
+        {"id": "ChangingBlocks", "minVersion": "0.1.1-SNAPSHOT"}
+    ],
     "isServerSideOnly" : false
 }


### PR DESCRIPTION
Added ChangingBlocks as a dependency in PlantPack. ChangingBlocks allows plants to go through the progressive growth stages. This prevents the user from having to manually select "ChangingBlocks" when they want to use PlantPack.