### PR TITLE
Update to work with CoreAssets + remove apache section from assets

### DIFF
--- a/assets/blocks/crop/Corn1.block
+++ b/assets/blocks/crop/Corn1.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Corn plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
     "author": "metouto",
-    "basedOn": "core:plant",
+    "basedOn": "CoreAssets:plant",
     "entity": {
         "prefab": "PlantPack:Corn",
         "keepActive": true

--- a/assets/blocks/crop/Corn2.block
+++ b/assets/blocks/crop/Corn2.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Corn plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
     "author": "metouto",
-    "basedOn": "core:plant",
+    "basedOn": "CoreAssets:plant",
     "entity": {
         "prefab": "PlantPack:Corn",
         "keepActive": true

--- a/assets/blocks/crop/Corn3.block
+++ b/assets/blocks/crop/Corn3.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Corn plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
     "author": "metouto",
-    "basedOn": "core:plant",
+    "basedOn": "CoreAssets:plant",
     "entity": {
         "prefab": "PlantPack:Corn",
         "keepActive": true

--- a/assets/blocks/crop/Corn4.block
+++ b/assets/blocks/crop/Corn4.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Corn plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
     "author": "metouto",
-    "basedOn": "core:plant",
+    "basedOn": "CoreAssets:plant",
     "entity": {
         "prefab": "PlantPack:Corn",
         "keepActive": true

--- a/assets/blocks/crop/Corn5.block
+++ b/assets/blocks/crop/Corn5.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Corn plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
     "author": "metouto",
-    "basedOn": "core:plant",
+    "basedOn": "CoreAssets:plant",
     "entity": {
         "prefab": "PlantPack:Corn",
         "keepActive": true

--- a/assets/blocks/crop/Corn6.block
+++ b/assets/blocks/crop/Corn6.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Corn plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
     "author": "metouto",
-    "basedOn": "core:plant",
+    "basedOn": "CoreAssets:plant",
     "entity": {
         "prefab": "PlantPack:Corn",
         "keepActive": true

--- a/assets/blocks/crop/Corn7.block
+++ b/assets/blocks/crop/Corn7.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Corn plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
     "author": "metouto",
-    "basedOn": "core:plant",
+    "basedOn": "CoreAssets:plant",
     "entity": {
         "prefab": "PlantPack:Corn",
         "keepActive": true

--- a/assets/blocks/crop/HotCoffeePlant1.block
+++ b/assets/blocks/crop/HotCoffeePlant1.block
@@ -20,7 +20,7 @@
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:HotCoffeePlant",
     "keepActive": true

--- a/assets/blocks/crop/HotCoffeePlant2.block
+++ b/assets/blocks/crop/HotCoffeePlant2.block
@@ -20,7 +20,7 @@
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:HotCoffeePlant",
     "keepActive": true

--- a/assets/blocks/crop/HotCoffeePlant3.block
+++ b/assets/blocks/crop/HotCoffeePlant3.block
@@ -20,7 +20,7 @@
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:HotCoffeePlant",
     "keepActive": true

--- a/assets/blocks/crop/HotCoffeePlant4.block
+++ b/assets/blocks/crop/HotCoffeePlant4.block
@@ -20,7 +20,7 @@
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:HotCoffeePlant",
     "keepActive": true

--- a/assets/blocks/crop/HotCoffeePlant5.block
+++ b/assets/blocks/crop/HotCoffeePlant5.block
@@ -20,7 +20,7 @@
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:HotCoffeePlant",
     "keepActive": true

--- a/assets/blocks/crop/HotCoffeePlant6.block
+++ b/assets/blocks/crop/HotCoffeePlant6.block
@@ -20,7 +20,7 @@
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:HotCoffeePlant",
     "keepActive": true

--- a/assets/blocks/crop/HotCoffeePlant7.block
+++ b/assets/blocks/crop/HotCoffeePlant7.block
@@ -20,7 +20,7 @@
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:HotCoffeePlant",
     "keepActive": true

--- a/assets/blocks/crop/MilkPlant1.block
+++ b/assets/blocks/crop/MilkPlant1.block
@@ -20,7 +20,7 @@
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:MilkPlant",
     "keepActive": true

--- a/assets/blocks/crop/MilkPlant2.block
+++ b/assets/blocks/crop/MilkPlant2.block
@@ -20,7 +20,7 @@
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:MilkPlant",
     "keepActive": true

--- a/assets/blocks/crop/MilkPlant3.block
+++ b/assets/blocks/crop/MilkPlant3.block
@@ -20,7 +20,7 @@
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:MilkPlant",
     "keepActive": true

--- a/assets/blocks/crop/MilkPlant4.block
+++ b/assets/blocks/crop/MilkPlant4.block
@@ -20,7 +20,7 @@
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:MilkPlant",
     "keepActive": true

--- a/assets/blocks/crop/MilkPlant5.block
+++ b/assets/blocks/crop/MilkPlant5.block
@@ -20,7 +20,7 @@
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:MilkPlant",
     "keepActive": true

--- a/assets/blocks/crop/MilkPlant6.block
+++ b/assets/blocks/crop/MilkPlant6.block
@@ -20,7 +20,7 @@
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:MilkPlant",
     "keepActive": true

--- a/assets/blocks/crop/MilkPlant7.block
+++ b/assets/blocks/crop/MilkPlant7.block
@@ -20,7 +20,7 @@
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:MilkPlant",
     "keepActive": true

--- a/assets/blocks/crop/Potato1.block
+++ b/assets/blocks/crop/Potato1.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Potato plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Potato",
     "keepActive": true

--- a/assets/blocks/crop/Potato2.block
+++ b/assets/blocks/crop/Potato2.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Potato plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Potato",
     "keepActive": true

--- a/assets/blocks/crop/Potato3.block
+++ b/assets/blocks/crop/Potato3.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Potato plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Potato",
     "keepActive": true

--- a/assets/blocks/crop/Potato4.block
+++ b/assets/blocks/crop/Potato4.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Potato plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Potato",
     "keepActive": true

--- a/assets/blocks/crop/Potato5.block
+++ b/assets/blocks/crop/Potato5.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Potato plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Potato",
     "keepActive": true

--- a/assets/blocks/crop/Potato6.block
+++ b/assets/blocks/crop/Potato6.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Potato plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Potato",
     "keepActive": true

--- a/assets/blocks/crop/Radish1.block
+++ b/assets/blocks/crop/Radish1.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Radish plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Radish",
     "keepActive": true

--- a/assets/blocks/crop/Radish2.block
+++ b/assets/blocks/crop/Radish2.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Radish plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Radish",
     "keepActive": true

--- a/assets/blocks/crop/Radish3.block
+++ b/assets/blocks/crop/Radish3.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Radish plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Radish",
     "keepActive": true

--- a/assets/blocks/crop/Radish4.block
+++ b/assets/blocks/crop/Radish4.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Radish plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Radish",
     "keepActive": true

--- a/assets/blocks/crop/Radish5.block
+++ b/assets/blocks/crop/Radish5.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Radish plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Radish",
     "keepActive": true

--- a/assets/blocks/crop/Rice1.block
+++ b/assets/blocks/crop/Rice1.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Radish plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
     "author": "metouto",
-    "basedOn": "core:plant",
+    "basedOn": "CoreAssets:plant",
     "entity": {
         "prefab": "PlantPack:Rice",
         "keepActive": true

--- a/assets/blocks/crop/Rice2.block
+++ b/assets/blocks/crop/Rice2.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Radish plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
     "author": "metouto",
-    "basedOn": "core:plant",
+    "basedOn": "CoreAssets:plant",
     "entity": {
         "prefab": "PlantPack:Rice",
         "keepActive": true

--- a/assets/blocks/crop/Rice3.block
+++ b/assets/blocks/crop/Rice3.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Radish plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
     "author": "metouto",
-    "basedOn": "core:plant",
+    "basedOn": "CoreAssets:plant",
     "entity": {
         "prefab": "PlantPack:Rice",
         "keepActive": true

--- a/assets/blocks/crop/Rice4.block
+++ b/assets/blocks/crop/Rice4.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Radish plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
     "author": "metouto",
-    "basedOn": "core:plant",
+    "basedOn": "CoreAssets:plant",
     "entity": {
         "prefab": "PlantPack:Rice",
         "keepActive": true

--- a/assets/blocks/crop/Squash1.block
+++ b/assets/blocks/crop/Squash1.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Squash plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Squash",
     "keepActive": true

--- a/assets/blocks/crop/Squash2.block
+++ b/assets/blocks/crop/Squash2.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Squash plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Squash",
     "keepActive": true

--- a/assets/blocks/crop/Squash3.block
+++ b/assets/blocks/crop/Squash3.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Squash plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Squash",
     "keepActive": true

--- a/assets/blocks/crop/Squash4.block
+++ b/assets/blocks/crop/Squash4.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Squash plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Squash",
     "keepActive": true

--- a/assets/blocks/crop/Squash5.block
+++ b/assets/blocks/crop/Squash5.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Squash plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Squash",
     "keepActive": true

--- a/assets/blocks/crop/SugarCane1.block
+++ b/assets/blocks/crop/SugarCane1.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Radish plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:SugarCane",
     "keepActive": true

--- a/assets/blocks/crop/SugarCane2.block
+++ b/assets/blocks/crop/SugarCane2.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Radish plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:SugarCane",
     "keepActive": true

--- a/assets/blocks/crop/SugarCane3.block
+++ b/assets/blocks/crop/SugarCane3.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Radish plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:SugarCane",
     "keepActive": true

--- a/assets/blocks/crop/SugarCane4.block
+++ b/assets/blocks/crop/SugarCane4.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Radish plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:SugarCane",
     "keepActive": true

--- a/assets/blocks/crop/SugarCane5.block
+++ b/assets/blocks/crop/SugarCane5.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Radish plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:SugarCane",
     "keepActive": true

--- a/assets/blocks/crop/Tomato1.block
+++ b/assets/blocks/crop/Tomato1.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Tomato plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Tomato",
     "keepActive": true

--- a/assets/blocks/crop/Tomato2.block
+++ b/assets/blocks/crop/Tomato2.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Tomato plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Tomato",
     "keepActive": true

--- a/assets/blocks/crop/Tomato3.block
+++ b/assets/blocks/crop/Tomato3.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Tomato plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Tomato",
     "keepActive": true

--- a/assets/blocks/crop/Tomato4.block
+++ b/assets/blocks/crop/Tomato4.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Tomato plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Tomato",
     "keepActive": true

--- a/assets/blocks/crop/Turnip1.block
+++ b/assets/blocks/crop/Turnip1.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Turnip plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Turnip",
     "keepActive": true

--- a/assets/blocks/crop/Turnip2.block
+++ b/assets/blocks/crop/Turnip2.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Turnip plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Turnip",
     "keepActive": true

--- a/assets/blocks/crop/Turnip3.block
+++ b/assets/blocks/crop/Turnip3.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Turnip plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Turnip",
     "keepActive": true

--- a/assets/blocks/crop/Turnip4.block
+++ b/assets/blocks/crop/Turnip4.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Turnip plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Turnip",
     "keepActive": true

--- a/assets/blocks/crop/Turnip5.block
+++ b/assets/blocks/crop/Turnip5.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Turnip plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Turnip",
     "keepActive": true

--- a/assets/blocks/crop/Watermelon1.block
+++ b/assets/blocks/crop/Watermelon1.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Watermelon plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Watermelon",
     "keepActive": true

--- a/assets/blocks/crop/Watermelon2.block
+++ b/assets/blocks/crop/Watermelon2.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Watermelon plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Watermelon",
     "keepActive": true

--- a/assets/blocks/crop/Watermelon3.block
+++ b/assets/blocks/crop/Watermelon3.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Watermelon plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Watermelon",
     "keepActive": true

--- a/assets/blocks/crop/Watermelon4.block
+++ b/assets/blocks/crop/Watermelon4.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Watermelon plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Watermelon",
     "keepActive": true

--- a/assets/blocks/crop/Watermelon5.block
+++ b/assets/blocks/crop/Watermelon5.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Watermelon plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Watermelon",
     "keepActive": true

--- a/assets/blocks/crop/Watermelon6.block
+++ b/assets/blocks/crop/Watermelon6.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Watermelon plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:Watermelon",
     "keepActive": true

--- a/assets/blocks/crop/WildCarrot1.block
+++ b/assets/blocks/crop/WildCarrot1.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Wild Carrot plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:WildCarrot",
     "keepActive": true

--- a/assets/blocks/crop/WildCarrot2.block
+++ b/assets/blocks/crop/WildCarrot2.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Wild Carrot plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:WildCarrot",
     "keepActive": true

--- a/assets/blocks/crop/WildCarrot3.block
+++ b/assets/blocks/crop/WildCarrot3.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Wild Carrot plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:WildCarrot",
     "keepActive": true

--- a/assets/blocks/crop/WildCarrot4.block
+++ b/assets/blocks/crop/WildCarrot4.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Wild Carrot plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:WildCarrot",
     "keepActive": true

--- a/assets/blocks/crop/WildCarrot5.block
+++ b/assets/blocks/crop/WildCarrot5.block
@@ -1,26 +1,10 @@
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Wild Carrot plant in various stages of its life-cycle
  * @author (art) metouto
  */
 {
   "author": "metouto",
-  "basedOn": "core:plant",
+  "basedOn": "CoreAssets:plant",
   "entity": {
     "prefab": "PlantPack:WildCarrot",
     "keepActive": true

--- a/assets/blocks/tree/birch/BirchLeaf.block
+++ b/assets/blocks/tree/birch/BirchLeaf.block
@@ -1,20 +1,6 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
-    "basedOn": "core:leaf",
+    "basedOn": "CoreAssets:leaf",
     "entity": {
         "prefab": "PlantPack:BirchLeaf"
     }

--- a/assets/blocks/tree/birch/BirchSapling.block
+++ b/assets/blocks/tree/birch/BirchSapling.block
@@ -1,5 +1,5 @@
 {
-    "basedOn": "core:plant",
+    "basedOn": "CoreAssets:plant",
     "displayName": "Birch Sapling",
     "entity": {
         "prefab": "PlantPack:BirchSapling"

--- a/assets/blocks/tree/birch/BirchTrunk.block
+++ b/assets/blocks/tree/birch/BirchTrunk.block
@@ -1,24 +1,10 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
     "hardness": 8,
     "displayName": "Birch Trunk",
 
     "categories": ["wood"],
-    "sounds": "Core:wood",
+    "sounds": "CoreAssets:wood",
     "entity": {
         "prefab": "PlantPack:BirchTrunk"
     },

--- a/assets/blocks/tree/blueSpruce/BlueSpruceLeaf.block
+++ b/assets/blocks/tree/blueSpruce/BlueSpruceLeaf.block
@@ -1,18 +1,4 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
     "attachmentAllowed" : false,
     "hardness" : 1,

--- a/assets/blocks/tree/blueSpruce/BlueSpruceSapling.block
+++ b/assets/blocks/tree/blueSpruce/BlueSpruceSapling.block
@@ -1,5 +1,5 @@
 {
-    "basedOn": "core:plant",
+    "basedOn": "CoreAssets:plant",
     "displayName": "BlueSpruce Sapling",
     "entity": {
         "prefab": "PlantPack:BlueSpruceSapling"

--- a/assets/blocks/tree/blueSpruce/BlueSpruceTrunk.block
+++ b/assets/blocks/tree/blueSpruce/BlueSpruceTrunk.block
@@ -1,24 +1,10 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
     "hardness": 7,
     "displayName": "BlueSpruce Trunk",
 
     "categories": ["wood"],
-    "sounds": "Core:wood",
+    "sounds": "CoreAssets:wood",
     "entity": {
         "prefab": "PlantPack:BlueSpruceTrunk"
     },

--- a/assets/blocks/tree/broom/BroomLeaf.block
+++ b/assets/blocks/tree/broom/BroomLeaf.block
@@ -1,18 +1,4 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
     "attachmentAllowed" : false,
     "hardness" : 1,

--- a/assets/blocks/tree/broom/BroomSapling.block
+++ b/assets/blocks/tree/broom/BroomSapling.block
@@ -1,5 +1,5 @@
 {
-    "basedOn": "core:plant",
+    "basedOn": "CoreAssets:plant",
     "displayName": "Broom Sapling",
     "entity": {
         "prefab": "PlantPack:BroomSapling"

--- a/assets/blocks/tree/broom/BroomTrunk.block
+++ b/assets/blocks/tree/broom/BroomTrunk.block
@@ -1,24 +1,10 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
     "hardness": 2,
     "displayName": "Broom Trunk",
 
     "categories": ["wood"],
-    "sounds": "Core:wood",
+    "sounds": "CoreAssets:wood",
     "entity": {
         "prefab": "PlantPack:BroomTrunk"
     },

--- a/assets/blocks/tree/cypress/CypressLeaf.block
+++ b/assets/blocks/tree/cypress/CypressLeaf.block
@@ -1,20 +1,6 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
-    "basedOn": "core:leaf",
+    "basedOn": "CoreAssets:leaf",
     "entity": {
         "prefab": "PlantPack:CypressLeaf"
     }

--- a/assets/blocks/tree/cypress/CypressSapling.block
+++ b/assets/blocks/tree/cypress/CypressSapling.block
@@ -1,5 +1,5 @@
 {
-    "basedOn": "core:plant",
+    "basedOn": "CoreAssets:plant",
     "displayName": "Cypress Sapling",
     "entity": {
         "prefab": "PlantPack:CypressSapling"

--- a/assets/blocks/tree/cypress/CypressTrunk.block
+++ b/assets/blocks/tree/cypress/CypressTrunk.block
@@ -1,24 +1,10 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
     "hardness": 8,
     "displayName": "Cypress Trunk",
 
     "categories": ["wood"],
-    "sounds": "Core:wood",
+    "sounds": "CoreAssets:wood",
     "entity": {
         "prefab": "PlantPack:CypressTrunk"
     },

--- a/assets/blocks/tree/grandMaple/GrandMapleLeaf.block
+++ b/assets/blocks/tree/grandMaple/GrandMapleLeaf.block
@@ -1,20 +1,6 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
-    "basedOn": "core:leaf",
+    "basedOn": "CoreAssets:leaf",
     "entity": {
         "prefab": "PlantPack:GrandMapleLeaf"
     }

--- a/assets/blocks/tree/grandMaple/GrandMapleSapling.block
+++ b/assets/blocks/tree/grandMaple/GrandMapleSapling.block
@@ -1,5 +1,5 @@
 {
-    "basedOn": "core:plant",
+    "basedOn": "CoreAssets:plant",
     "displayName": "GrandMaple Sapling",
     "entity": {
         "prefab": "PlantPack:GrandMapleSapling"

--- a/assets/blocks/tree/grandMaple/GrandMapleTrunk.block
+++ b/assets/blocks/tree/grandMaple/GrandMapleTrunk.block
@@ -1,24 +1,10 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
     "hardness": 7,
     "displayName": "GrandMaple Trunk",
 
     "categories": ["wood"],
-    "sounds": "Core:wood",
+    "sounds": "CoreAssets:wood",
     "entity": {
         "prefab": "PlantPack:GrandMapleTrunk"
     },

--- a/assets/blocks/tree/longPine/LongPineLeaf.block
+++ b/assets/blocks/tree/longPine/LongPineLeaf.block
@@ -1,20 +1,6 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
-    "basedOn": "core:leaf",
+    "basedOn": "CoreAssets:leaf",
     "entity": {
         "prefab": "PlantPack:LongPineLeaf"
     }

--- a/assets/blocks/tree/longPine/LongPineSapling.block
+++ b/assets/blocks/tree/longPine/LongPineSapling.block
@@ -1,5 +1,5 @@
 {
-    "basedOn": "core:plant",
+    "basedOn": "CoreAssets:plant",
     "displayName": "LongPine Sapling",
     "entity": {
         "prefab": "PlantPack:LongPineSapling"

--- a/assets/blocks/tree/longPine/LongPineTrunk.block
+++ b/assets/blocks/tree/longPine/LongPineTrunk.block
@@ -1,24 +1,10 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
     "hardness": 5,
     "displayName": "LongPine Trunk",
 
     "categories": ["wood"],
-    "sounds": "Core:wood",
+    "sounds": "CoreAssets:wood",
     "entity": {
         "prefab": "PlantPack:LongPineTrunk"
     },

--- a/assets/blocks/tree/maple/MapleLeaf.block
+++ b/assets/blocks/tree/maple/MapleLeaf.block
@@ -1,20 +1,6 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
-    "basedOn": "core:leaf",
+    "basedOn": "CoreAssets:leaf",
     "entity": {
         "prefab": "PlantPack:MapleLeaf"
     }

--- a/assets/blocks/tree/maple/MapleSapling.block
+++ b/assets/blocks/tree/maple/MapleSapling.block
@@ -1,5 +1,5 @@
 {
-    "basedOn": "core:plant",
+    "basedOn": "CoreAssets:plant",
     "displayName": "Maple Sapling",
     "entity": {
         "prefab": "PlantPack:MapleSapling"

--- a/assets/blocks/tree/maple/MapleTrunk.block
+++ b/assets/blocks/tree/maple/MapleTrunk.block
@@ -1,24 +1,10 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
     "hardness": 6,
     "displayName": "Pine Trunk",
 
     "categories": ["wood"],
-    "sounds": "Core:wood",
+    "sounds": "CoreAssets:wood",
     "entity": {
         "prefab": "PlantPack:MapleTrunk"
     },

--- a/assets/blocks/tree/mithroot/MithrootLeaf.block
+++ b/assets/blocks/tree/mithroot/MithrootLeaf.block
@@ -1,18 +1,4 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
     "attachmentAllowed" : false,
     "hardness" : 1,

--- a/assets/blocks/tree/mithroot/MithrootSapling.block
+++ b/assets/blocks/tree/mithroot/MithrootSapling.block
@@ -1,5 +1,5 @@
 {
-    "basedOn": "core:plant",
+    "basedOn": "CoreAssets:plant",
     "displayName": "Mithroot Sapling",
     "shadowCasting" : false,
     "luminance" : 3,

--- a/assets/blocks/tree/mithroot/MithrootTrunk.block
+++ b/assets/blocks/tree/mithroot/MithrootTrunk.block
@@ -1,23 +1,9 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
     "hardness": 10,
     "luminance": 1,
     "displayName": "Mithroot Trunk",
-    "sounds": "Core:wood",
+    "sounds": "CoreAssets:wood",
     "categories": ["wood"],
 
     "entity": {

--- a/assets/blocks/tree/oak/OakLeaf.block
+++ b/assets/blocks/tree/oak/OakLeaf.block
@@ -1,20 +1,6 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
-    "basedOn": "core:leaf",
+    "basedOn": "CoreAssets:leaf",
     "entity": {
         "prefab": "PlantPack:OakLeaf"
     }

--- a/assets/blocks/tree/oak/OakSapling.block
+++ b/assets/blocks/tree/oak/OakSapling.block
@@ -1,5 +1,5 @@
 {
-    "basedOn": "core:plant",
+    "basedOn": "CoreAssets:plant",
     "displayName": "Oak Sapling",
     "entity": {
         "prefab": "PlantPack:OakSapling"

--- a/assets/blocks/tree/oak/OakTrunk.block
+++ b/assets/blocks/tree/oak/OakTrunk.block
@@ -1,24 +1,10 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
     "hardness": 6,
     "displayName": "Oak Trunk",
 
     "categories": ["wood"],
-    "sounds": "Core:wood",
+    "sounds": "CoreAssets:wood",
     "entity": {
         "prefab": "PlantPack:OakTrunk"
     },

--- a/assets/blocks/tree/pine/PineLeaf.block
+++ b/assets/blocks/tree/pine/PineLeaf.block
@@ -1,20 +1,6 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
-    "basedOn": "core:leaf",
+    "basedOn": "CoreAssets:leaf",
     "entity": {
         "prefab": "PlantPack:PineLeaf"
     }

--- a/assets/blocks/tree/pine/PineSapling.block
+++ b/assets/blocks/tree/pine/PineSapling.block
@@ -1,5 +1,5 @@
 {
-    "basedOn": "core:plant",
+    "basedOn": "CoreAssets:plant",
     "displayName": "Pine Sapling",
     "entity": {
         "prefab": "PlantPack:PineSapling"

--- a/assets/blocks/tree/pine/PineTrunk.block
+++ b/assets/blocks/tree/pine/PineTrunk.block
@@ -1,24 +1,10 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
     "hardness": 6,
     "displayName": "Pine Trunk",
 
     "categories": ["wood"],
-    "sounds": "Core:wood",
+    "sounds": "CoreAssets:wood",
     "entity": {
         "prefab": "PlantPack:PineTrunk"
     },

--- a/assets/blocks/tree/sakura/SakuraLeaf.block
+++ b/assets/blocks/tree/sakura/SakuraLeaf.block
@@ -1,18 +1,4 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
     "attachmentAllowed" : false,
     "hardness" : 1,

--- a/assets/blocks/tree/sakura/SakuraSapling.block
+++ b/assets/blocks/tree/sakura/SakuraSapling.block
@@ -1,5 +1,5 @@
 {
-    "basedOn": "core:plant",
+    "basedOn": "CoreAssets:plant",
     "displayName": "Sakura Sapling",
     "entity": {
         "prefab": "PlantPack:SakuraSapling"

--- a/assets/blocks/tree/sakura/SakuraTrunk.block
+++ b/assets/blocks/tree/sakura/SakuraTrunk.block
@@ -1,24 +1,10 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
     "hardness": 7,
     "displayName": "Sakura Trunk",
 
     "categories": ["wood"],
-    "sounds": "Core:wood",
+    "sounds": "CoreAssets:wood",
     "entity": {
         "prefab": "PlantPack:SakuraTrunk"
     },

--- a/assets/blocks/tree/spruce/SpruceLeaf.block
+++ b/assets/blocks/tree/spruce/SpruceLeaf.block
@@ -1,20 +1,6 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
-    "basedOn": "core:leaf",
+    "basedOn": "CoreAssets:leaf",
     "entity": {
         "prefab": "PlantPack:SpruceLeaf"
     }

--- a/assets/blocks/tree/spruce/SpruceSapling.block
+++ b/assets/blocks/tree/spruce/SpruceSapling.block
@@ -1,5 +1,5 @@
 {
-    "basedOn": "core:plant",
+    "basedOn": "CoreAssets:plant",
     "displayName": "Spruce Sapling",
     "entity": {
         "prefab": "PlantPack:SpruceSapling"

--- a/assets/blocks/tree/spruce/SpruceTrunk.block
+++ b/assets/blocks/tree/spruce/SpruceTrunk.block
@@ -1,24 +1,10 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
     "hardness": 6,
     "displayName": "Spruce Trunk",
 
     "categories": ["wood"],
-    "sounds": "Core:wood",
+    "sounds": "CoreAssets:wood",
     "entity": {
         "prefab": "PlantPack:SpruceTrunk"
     },

--- a/assets/blocks/tree/stisus/StisusLeaf.block
+++ b/assets/blocks/tree/stisus/StisusLeaf.block
@@ -1,18 +1,4 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
     "attachmentAllowed" : false,
     "hardness" : 1,

--- a/assets/blocks/tree/stisus/StisusSapling.block
+++ b/assets/blocks/tree/stisus/StisusSapling.block
@@ -1,5 +1,5 @@
 {
-    "basedOn": "core:plant",
+    "basedOn": "CoreAssets:plant",
     "displayName": "Stisus Sapling",
     "shadowCasting" : false,
     "luminance" : 10,

--- a/assets/blocks/tree/stisus/StisusTrunk.block
+++ b/assets/blocks/tree/stisus/StisusTrunk.block
@@ -1,25 +1,11 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
     "hardness": 6,
     "luminance": 2,
     "displayName": "Stisus Trunk",
 
     "categories": ["wood"],
-    "sounds": "Core:wood",
+    "sounds": "CoreAssets:wood",
     "entity": {
         "prefab": "PlantPack:StisusTrunk"
     },

--- a/assets/prefabs/crop/Corn.prefab
+++ b/assets/prefabs/crop/Corn.prefab
@@ -1,18 +1,4 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
   "ChangingBlocks": {
     "blockFamilyStages": {

--- a/assets/prefabs/crop/Oreo.prefab
+++ b/assets/prefabs/crop/Oreo.prefab
@@ -1,18 +1,4 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
   "ChangingBlocks": {
     "blockFamilyStages": {

--- a/assets/prefabs/crop/Potato.prefab
+++ b/assets/prefabs/crop/Potato.prefab
@@ -1,18 +1,4 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
   "ChangingBlocks": {
     "blockFamilyStages": {

--- a/assets/prefabs/crop/Radish.prefab
+++ b/assets/prefabs/crop/Radish.prefab
@@ -1,18 +1,4 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
   "ChangingBlocks": {
     "blockFamilyStages": {

--- a/assets/prefabs/crop/Rice.prefab
+++ b/assets/prefabs/crop/Rice.prefab
@@ -1,18 +1,4 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
   "ChangingBlocks": {
     "blockFamilyStages": {

--- a/assets/prefabs/crop/Squash.prefab
+++ b/assets/prefabs/crop/Squash.prefab
@@ -1,18 +1,4 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
   "ChangingBlocks": {
     "blockFamilyStages": {

--- a/assets/prefabs/crop/SugarCane.prefab
+++ b/assets/prefabs/crop/SugarCane.prefab
@@ -1,18 +1,4 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
   "ChangingBlocks": {
     "blockFamilyStages": {

--- a/assets/prefabs/crop/Tomato.prefab
+++ b/assets/prefabs/crop/Tomato.prefab
@@ -1,18 +1,4 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
   "ChangingBlocks": {
     "blockFamilyStages": {

--- a/assets/prefabs/crop/Turnip.prefab
+++ b/assets/prefabs/crop/Turnip.prefab
@@ -1,18 +1,4 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
   "ChangingBlocks": {
     "blockFamilyStages": {

--- a/assets/prefabs/crop/Watermelon.prefab
+++ b/assets/prefabs/crop/Watermelon.prefab
@@ -1,18 +1,4 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
   "ChangingBlocks": {
     "blockFamilyStages": {

--- a/assets/prefabs/crop/WildCarrot.prefab
+++ b/assets/prefabs/crop/WildCarrot.prefab
@@ -1,18 +1,4 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
 {
   "ChangingBlocks": {
     "blockFamilyStages": {

--- a/module.txt
+++ b/module.txt
@@ -4,6 +4,8 @@
     "author" : "Marcin Sciesinski <marcins78@gmail.com>, Esa-Petri, Metouto, Josharias, Skaldarnar",
     "displayName" : "PlantPack",
     "description" : "Provides basic plant assets",
-    "dependencies" : [],
+    "dependencies" : [
+        {"id": "CoreAssets", "minVersion": "1.0.0"}
+    ],
     "isServerSideOnly" : false
 }


### PR DESCRIPTION
Also worth noting that it previously had a stealth dependency on Core, as Core was not listed as a dependency despite Core containing the templates for all the assets. It is now properly set to require CoreAssets.